### PR TITLE
Create link-vmlinux-preparation.sh

### DIFF
--- a/link-vmlinux-preparation.sh
+++ b/link-vmlinux-preparation.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Created by Deokgyu Yang <secugyu@gmail.com>
+
+# Create a soft link file named ld for use lld to fix the build error on modern clang
+# Remove "/clang" from $HOSTCC string
+CLANG_BIN="${HOSTCC:0:(-6)}"
+if [ ! -f "${CLANG_BIN}/ld" ]; then
+    ln -s "${CLANG_BIN}/lld" "${CLANG_BIN}/ld"
+fi

--- a/scripts/link-vmlinux.sh
+++ b/scripts/link-vmlinux.sh
@@ -228,5 +228,11 @@ if [ -n "${CONFIG_KALLSYMS}" ]; then
 	fi
 fi
 
+
+if [ -f "${srctree}/link-vmlinux-preparation.sh" ]; then
+    "${srctree}/link-vmlinux-preparation.sh"
+fi
+
+
 # We made a new kernel - delete old version file
 rm -f .old_version


### PR DESCRIPTION
The "ld" command no longer exists in the modern clang binaries